### PR TITLE
Bump platform and asio

### DIFF
--- a/lock_version_resolve.json
+++ b/lock_version_resolve.json
@@ -10,14 +10,14 @@
         "sha1": "672c4c4d312b34f23e0461486087863d132c042c"
     },
     "asio": {
-        "commit_id": "e17f46a631fac2c9181553ec6b7971b6c9987d0d",
-        "resolver_info": "2.0.1",
-        "sha1": "744549192663ff615bc3a59793bb3f92d143ce75"
+        "commit_id": "4d8b20130eed41bbb27570192514029b53c9f6da",
+        "resolver_info": "3.0.0",
+        "sha1": "939f27ad7766ed0924ddfa22dca123f6177644fe"
     },
     "asio-source": {
-        "commit_id": "147f7225a96d45a2807a64e443177f621844e51c",
-        "resolver_info": "asio-1-24-0",
-        "sha1": "bb0e4dc8f3c4f60822b15c54003556ef448c22e8"
+        "commit_id": "12e0ce9e0500bf0f247dbd1ae894272656456079",
+        "resolver_info": "asio-1-30-2",
+        "sha1": "92335e88366200b45048869bb28668e46f01192b"
     },
     "bourne": {
         "commit_id": "97a913859ef89817f97ab5fb59d82989319cd33f",
@@ -55,8 +55,8 @@
         "sha1": "ca969a1500e88a09de1cbfb8d8d3307a7773abfd"
     },
     "platform": {
-        "commit_id": "576ad99a67d4a3a6566509485de1de6b28ef21af",
-        "resolver_info": "5.0.0",
+        "commit_id": "c2543dd5e613fb86d8dee530c0f1c142a310e1f0",
+        "resolver_info": "5.1.1",
         "sha1": "f6bc772cf920c024726ebd12a5a38f123d057adb"
     },
     "poke": {

--- a/resolve.json
+++ b/resolve.json
@@ -50,7 +50,7 @@
         "internal": true,
         "resolver": "git",
         "method": "semver",
-        "major": 2,
+        "major": 3,
         "sources": [
             "github.com/steinwurf/asio.git"
         ]


### PR DESCRIPTION
Bumps [platform](https://github.com/steinwurf/platform) and [asio](https://github.com/steinwurf/asio). These dependencies needed to be updated together.
Updates `platform` from 5.0.0 to 5.1.1
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/steinwurf/platform/commit/c2543dd5e613fb86d8dee530c0f1c142a310e1f0"><code>c2543dd</code></a> Preparing to create tag 5.1.1</li>
<li><a href="https://github.com/steinwurf/platform/commit/7f3a57a19d54411abd479ed506e59e382fc70ab8"><code>7f3a57a</code></a> Merge pull request <a href="https://redirect.github.com/steinwurf/platform/issues/26">#26</a> from steinwurf/fix-freebsd</li>
<li><a href="https://github.com/steinwurf/platform/commit/490d64065f8252de3bbf0f29a48ea77d47b1bc6a"><code>490d640</code></a> fix freebsd</li>
<li><a href="https://github.com/steinwurf/platform/commit/154597a353125e804ff327842533c76f5e4d549f"><code>154597a</code></a> Preparing to create tag 5.1.0</li>
<li><a href="https://github.com/steinwurf/platform/commit/50adaaebd341f1780c59ecde82947533e43b49a5"><code>50adaae</code></a> trigger</li>
<li><a href="https://github.com/steinwurf/platform/commit/a52e2c35b0ff17caad16fa8c8ab10f304ec8ed72"><code>a52e2c3</code></a> update test</li>
<li><a href="https://github.com/steinwurf/platform/commit/defe056de54abcb7a774c8217d1df204ecf541cc"><code>defe056</code></a> added support for freebsd!</li>
<li><a href="https://github.com/steinwurf/platform/commit/89ee6e96dbfd90b0acd1deb917bbb6ba44023029"><code>89ee6e9</code></a> Update workflow to run on push to master</li>
<li><a href="https://github.com/steinwurf/platform/commit/ea02d84858bdfbfd64a0888c0e8627d453cc3f7f"><code>ea02d84</code></a> Update workflow to run on push to master</li>
<li><a href="https://github.com/steinwurf/platform/commit/159afcf327787d728734af4da5f1f23e70ec2ed5"><code>159afcf</code></a> Update workflow to run on push to master</li>
<li>Additional commits viewable in <a href="https://github.com/steinwurf/platform/compare/5.0.0...5.1.1">compare view</a></li>
</ul>
</details>
<br />

Updates `asio` from 2.0.1 to 3.0.0
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/steinwurf/asio/commit/4d8b20130eed41bbb27570192514029b53c9f6da"><code>4d8b201</code></a> Preparing to create tag 3.0.0</li>
<li><a href="https://github.com/steinwurf/asio/commit/e99906d84499e006ade2b552a01a24ca09b02849"><code>e99906d</code></a> Merge pull request <a href="https://redirect.github.com/steinwurf/asio/issues/3">#3</a> from steinwurf/bump-asio-version</li>
<li><a href="https://github.com/steinwurf/asio/commit/20c3fa7b8165516ed071462807a9cd9f38c96765"><code>20c3fa7</code></a> update news</li>
<li><a href="https://github.com/steinwurf/asio/commit/3127a9cc174675ecfd463eff1a0f995b4fad505d"><code>3127a9c</code></a> remove test</li>
<li><a href="https://github.com/steinwurf/asio/commit/47d92afc6708f836f3b6c63b4fa521f19fb2e729"><code>47d92af</code></a> remove --ninja option from configure as this does not really matter in this case</li>
<li><a href="https://github.com/steinwurf/asio/commit/2506be3d204a71a69c8245fa7c8888c4241d3c2d"><code>2506be3</code></a> use new waf</li>
<li><a href="https://github.com/steinwurf/asio/commit/89f962bc18b48b913e7c0201bfba9bb23803fffb"><code>89f962b</code></a> remove tests</li>
<li><a href="https://github.com/steinwurf/asio/commit/c820670b24e46191bd72ab950a59ea6575a5988b"><code>c820670</code></a> update workflows</li>
<li><a href="https://github.com/steinwurf/asio/commit/2780dfc4191246c0b3048b73b2fc9d3dde01e09b"><code>2780dfc</code></a> bump asio version</li>
<li><a href="https://github.com/steinwurf/asio/commit/2ff4d3385e54980859214ddbb2b25d28353689b2"><code>2ff4d33</code></a> Update workflow to run on push to master</li>
<li>Additional commits viewable in <a href="https://github.com/steinwurf/asio/compare/2.0.1...3.0.0">compare view</a></li>
</ul>
</details>
<br />
