### PR TITLE
Bump poke and asio

### DIFF
--- a/lock_version_resolve.json
+++ b/lock_version_resolve.json
@@ -10,14 +10,14 @@
         "sha1": "d1447e30e2da0697d0ff07a6513a93734691dbdc"
     },
     "asio": {
-        "commit_id": "e17f46a631fac2c9181553ec6b7971b6c9987d0d",
-        "resolver_info": "2.0.1",
-        "sha1": "744549192663ff615bc3a59793bb3f92d143ce75"
+        "commit_id": "4d8b20130eed41bbb27570192514029b53c9f6da",
+        "resolver_info": "3.0.0",
+        "sha1": "939f27ad7766ed0924ddfa22dca123f6177644fe"
     },
     "asio-source": {
-        "commit_id": "147f7225a96d45a2807a64e443177f621844e51c",
-        "resolver_info": "asio-1-24-0",
-        "sha1": "bb0e4dc8f3c4f60822b15c54003556ef448c22e8"
+        "commit_id": "12e0ce9e0500bf0f247dbd1ae894272656456079",
+        "resolver_info": "asio-1-30-2",
+        "sha1": "92335e88366200b45048869bb28668e46f01192b"
     },
     "bourne": {
         "commit_id": "1288fa220b92e6910d9e09643b92ccf8f7f99b4e",
@@ -60,8 +60,8 @@
         "sha1": "f6bc772cf920c024726ebd12a5a38f123d057adb"
     },
     "poke": {
-        "commit_id": "1a4aa1ad78a2c3ecbb6055197807485b0c277da1",
-        "resolver_info": "15.0.0",
+        "commit_id": "1326578cc558e4d6047b35c683d9065a95743a5c",
+        "resolver_info": "15.0.2",
         "sha1": "55f4dfad5db131a8a2e1fe392d43d1ae4cdaf0a5"
     },
     "protobuf": {

--- a/resolve.json
+++ b/resolve.json
@@ -41,7 +41,7 @@
         "internal": true,
         "resolver": "git",
         "method": "semver",
-        "major": 2,
+        "major": 3,
         "sources": [
             "github.com/steinwurf/asio.git"
         ]


### PR DESCRIPTION
Bumps [poke](https://github.com/steinwurf/poke) and [asio](https://github.com/steinwurf/asio). These dependencies needed to be updated together.
Updates `poke` from 15.0.0 to 15.0.2
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/steinwurf/poke/commit/1326578cc558e4d6047b35c683d9065a95743a5c"><code>1326578</code></a> Preparing to create tag 15.0.2</li>
<li><a href="https://github.com/steinwurf/poke/commit/5a21aa9c3c3ab1cd396df9ac49afd97ccbe517b6"><code>5a21aa9</code></a> CMake 4.0.0 compat</li>
<li><a href="https://github.com/steinwurf/poke/commit/6af1dbe39fa78340e4594e872756496a38be97f8"><code>6af1dbe</code></a> Fix source_location (<a href="https://redirect.github.com/steinwurf/poke/issues/47">#47</a>)</li>
<li><a href="https://github.com/steinwurf/poke/commit/996cef786bdeec21af07ef3bd78ce6136edb03d7"><code>996cef7</code></a> Preparing to create tag 15.0.1</li>
<li><a href="https://github.com/steinwurf/poke/commit/fe78547e0959f9454733814d179de14ea15973b6"><code>fe78547</code></a> Merge pull request <a href="https://redirect.github.com/steinwurf/poke/issues/45">#45</a> from steinwurf/allow-shared-memory-file-open-after-aba...</li>
<li><a href="https://github.com/steinwurf/poke/commit/6e6db087f0e1ade446f4b1098fc4da35e9cc80df"><code>6e6db08</code></a> CMake in Waf + Update workflows + Keepalive steps in workflows (<a href="https://redirect.github.com/steinwurf/poke/issues/46">#46</a>)</li>
<li><a href="https://github.com/steinwurf/poke/commit/e6c177d5dda0377c5ddc6d16a986106991aa85ae"><code>e6c177d</code></a> Switched to safe memory reads</li>
<li><a href="https://github.com/steinwurf/poke/commit/3d55435ee4f7cfbd65cd237a41ce9a9b33a96440"><code>3d55435</code></a> Merge branch 'allow-shared-memory-file-open-after-abandon' of github.com:stei...</li>
<li><a href="https://github.com/steinwurf/poke/commit/91dc8625d9c7ea4cbf051974d81e8783f8bd39f5"><code>91dc862</code></a> fix?</li>
<li><a href="https://github.com/steinwurf/poke/commit/9eafb2a906fb688133f90971c899262bb645054f"><code>9eafb2a</code></a> Update test/src/test_shm_writer.cpp</li>
<li>Additional commits viewable in <a href="https://github.com/steinwurf/poke/compare/15.0.0...15.0.2">compare view</a></li>
</ul>
</details>
<br />

Updates `asio` from 2.0.1 to 3.0.0
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/steinwurf/asio/commit/4d8b20130eed41bbb27570192514029b53c9f6da"><code>4d8b201</code></a> Preparing to create tag 3.0.0</li>
<li><a href="https://github.com/steinwurf/asio/commit/e99906d84499e006ade2b552a01a24ca09b02849"><code>e99906d</code></a> Merge pull request <a href="https://redirect.github.com/steinwurf/asio/issues/3">#3</a> from steinwurf/bump-asio-version</li>
<li><a href="https://github.com/steinwurf/asio/commit/20c3fa7b8165516ed071462807a9cd9f38c96765"><code>20c3fa7</code></a> update news</li>
<li><a href="https://github.com/steinwurf/asio/commit/3127a9cc174675ecfd463eff1a0f995b4fad505d"><code>3127a9c</code></a> remove test</li>
<li><a href="https://github.com/steinwurf/asio/commit/47d92afc6708f836f3b6c63b4fa521f19fb2e729"><code>47d92af</code></a> remove --ninja option from configure as this does not really matter in this case</li>
<li><a href="https://github.com/steinwurf/asio/commit/2506be3d204a71a69c8245fa7c8888c4241d3c2d"><code>2506be3</code></a> use new waf</li>
<li><a href="https://github.com/steinwurf/asio/commit/89f962bc18b48b913e7c0201bfba9bb23803fffb"><code>89f962b</code></a> remove tests</li>
<li><a href="https://github.com/steinwurf/asio/commit/c820670b24e46191bd72ab950a59ea6575a5988b"><code>c820670</code></a> update workflows</li>
<li><a href="https://github.com/steinwurf/asio/commit/2780dfc4191246c0b3048b73b2fc9d3dde01e09b"><code>2780dfc</code></a> bump asio version</li>
<li><a href="https://github.com/steinwurf/asio/commit/2ff4d3385e54980859214ddbb2b25d28353689b2"><code>2ff4d33</code></a> Update workflow to run on push to master</li>
<li>Additional commits viewable in <a href="https://github.com/steinwurf/asio/compare/2.0.1...3.0.0">compare view</a></li>
</ul>
</details>
<br />
